### PR TITLE
Fix WFDB archives repository link

### DIFF
--- a/alienfile
+++ b/alienfile
@@ -5,7 +5,7 @@ share {
 	requires 'Path::Tiny' => 0;
 
 	plugin Download => (
-		url => 'https://physionet.org/physiotools/archives/',
+		url => 'https://archive.physionet.org/physiotools/archives/',
 		# the -no-docs archive is smaller, if it exists
 		version => qr/wfdb-([\d\.]+)-no-docs\.tar\.gz/,
 	);


### PR DESCRIPTION
Hello,

The link is broken see https://physionet.org/physiotools/archives/ 
Then Alien::WFDB no longer build (see this [failed build](https://github.com/thibaultduponchelle/aliens-ci/runs/658917515?check_suite_focus=true)) 

I updated it with this PR :)

Best regards.

Thibault